### PR TITLE
Updates dependencies and adds all-examples command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "php": "^8.2",
     "ext-pdo": "*",
     "psr/log": "^3.0",
-    "illuminate/contracts": "^11.0|^12.0",
     "illuminate/support": "^11.0|^12.0",
     "illuminate/pipeline": "^11.0|^12.0",
     "league/csv": "^9.24",

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,19 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
+    "ext-pdo": "*",
     "psr/log": "^3.0",
-    "illuminate/contracts": "^10.0",
-    "illuminate/support": "^10.0",
-    "illuminate/pipeline": "^10.0",
-    "league/csv": "^9.8",
-    "phpoffice/phpspreadsheet": "^1.27"
+    "illuminate/contracts": "^11.0|^12.0",
+    "illuminate/support": "^11.0|^12.0",
+    "illuminate/pipeline": "^11.0|^12.0",
+    "league/csv": "^9.24",
+    "phpoffice/phpspreadsheet": "^4.5"
   },
   "require-dev": {
-    "symfony/console": "^6.2",
-    "symfony/process": "^6.2",
-    "symfony/var-dumper": "^6.2"
+    "symfony/console": "^7.3",
+    "symfony/process": "^7.3",
+    "symfony/var-dumper": "^7.3"
   },
   "autoload": {
     "psr-4": {

--- a/console
+++ b/console
@@ -3,6 +3,7 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
+use RodrigoPedra\RecordProcessor\Examples\AllExamplesCommand;
 use RodrigoPedra\RecordProcessor\Examples\DownloadCommand;
 use RodrigoPedra\RecordProcessor\Examples\ExamplesCommand;
 use Symfony\Component\Console\Application;
@@ -10,6 +11,7 @@ use Symfony\Component\Console\Application;
 $application = new Application();
 
 $application->add(new ExamplesCommand());
+$application->add(new AllExamplesCommand());
 $application->add(new DownloadCommand());
 
 $application->run();

--- a/examples/AllExamplesCommand.php
+++ b/examples/AllExamplesCommand.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace RodrigoPedra\RecordProcessor\Examples;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\Table;
+
+class AllExamplesCommand extends ExamplesCommand
+{
+    protected ?string $currentParser = null;
+    protected ?string $currentSerializer = null;
+
+    protected function configure()
+    {
+        $this->setName('all-examples');
+        $this->setDescription('Tests all combinations of parsers and serializers to validate no errors exist');
+
+        $this->addOption('stop-on-error', 's', InputOption::VALUE_NONE, 'Stop execution on first error');
+        $this->addOption('verbose-errors', null, InputOption::VALUE_NONE, 'Show detailed error messages');
+        $this->addOption('skip-pdo', null, InputOption::VALUE_NONE, 'Skip PDO-related tests');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $parsers = $this->getParsers($input->getOption('skip-pdo'));
+        $serializers = $this->getSerializers($input->getOption('skip-pdo'));
+
+        $totalCombinations = count($parsers) * count($serializers);
+        $results = [];
+        $errors = [];
+
+        $output->writeln("<info>Testing {$totalCombinations} combinations...</info>");
+        $output->writeln("<comment>Parsers: " . implode(', ', $parsers) . "</comment>");
+        $output->writeln("<comment>Serializers: " . implode(', ', $serializers) . "</comment>");
+        $output->writeln('');
+
+        $progressBar = new ProgressBar($output, $totalCombinations);
+        $progressBar->setFormat('verbose');
+        $progressBar->start();
+
+        foreach ($parsers as $parser) {
+            foreach ($serializers as $serializer) {
+                $combination = "{$parser} → {$serializer}";
+
+                try {
+                    // Set current context for file naming
+                    $this->currentParser = $parser;
+                    $this->currentSerializer = $serializer;
+                    
+                    $this->testCombination($parser, $serializer);
+                    $results[] = ['combination' => $combination, 'status' => 'SUCCESS', 'error' => null];
+                    $progressBar->setMessage("✅ {$combination}", 'status');
+                } catch (\Throwable $e) {
+                    $errorMessage = $e->getMessage();
+                    $results[] = ['combination' => $combination, 'status' => 'FAILED', 'error' => $errorMessage];
+                    $errors[] = ['combination' => $combination, 'error' => $errorMessage];
+
+                    $progressBar->setMessage("❌ {$combination}", 'status');
+
+                    if ($input->getOption('stop-on-error')) {
+                        $progressBar->finish();
+                        $output->writeln('');
+                        $output->writeln("<error>Stopped on first error: {$combination}</error>");
+                        if ($input->getOption('verbose-errors')) {
+                            $output->writeln("<error>{$errorMessage}</error>");
+                        }
+                        return Command::FAILURE;
+                    }
+                } finally {
+                    // Clear context after test
+                    $this->currentParser = null;
+                    $this->currentSerializer = null;
+                }
+
+                $progressBar->advance();
+            }
+        }
+
+        $progressBar->finish();
+        $output->writeln('');
+        $output->writeln('');
+
+        $this->displayResults($output, $results, $errors, $input->getOption('verbose-errors'));
+
+        return empty($errors) ? Command::SUCCESS : Command::FAILURE;
+    }
+
+    protected function getParsers(bool $skipPdo): array
+    {
+        $parsers = ['array', 'collection', 'csv', 'excel', 'iterator', 'text'];
+
+        if (!$skipPdo) {
+            $parsers[] = 'pdo';
+        }
+
+        return $parsers;
+    }
+
+    protected function getSerializers(bool $skipPdo): array
+    {
+        $serializers = ['array', 'collection', 'csv', 'echo', 'excel', 'html', 'json', 'log', 'text'];
+
+        if (!$skipPdo) {
+            $serializers[] = 'pdo';
+            $serializers[] = 'pdo-buffered';
+        }
+
+        return $serializers;
+    }
+
+    protected function testCombination(string $parser, string $serializer): void
+    {
+        // Capture output to prevent verbose testing output
+        ob_start();
+
+        try {
+            // Create a minimal test to verify the combination works
+            $builder = $this->makeBuilder();
+
+            // Use a null logger to suppress output during testing
+            $builder->setLogger(new class implements \Psr\Log\LoggerInterface {
+                public function emergency($message, array $context = []): void {}
+                public function alert($message, array $context = []): void {}
+                public function critical($message, array $context = []): void {}
+                public function error($message, array $context = []): void {}
+                public function warning($message, array $context = []): void {}
+                public function notice($message, array $context = []): void {}
+                public function info($message, array $context = []): void {}
+                public function debug($message, array $context = []): void {}
+                public function log($level, $message, array $context = []): void {}
+            });
+
+            $builder->withRecordParser(new RecordObjects\ExampleRecordParser());
+            $builder->withRecordSerializer(new RecordObjects\ExampleRecordSerializer());
+
+            $this->readFrom($builder, $parser);
+
+            $builder->onlyValidRecords();
+
+            if (in_array($serializer, ['echo', 'log'])) {
+                $builder->serializeToArray();
+            } else {
+                $this->serializeTo($builder, $serializer);
+            }
+
+            $processor = $builder->build();
+            $result = $processor->process();
+
+            if ($result->inputRecordCount() === 0) {
+                throw new \RuntimeException('No records were processed');
+            }
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    protected function displayResults(OutputInterface $output, array $results, array $errors, bool $verboseErrors): void
+    {
+        $successCount = count($results) - count($errors);
+        $failureCount = count($errors);
+        $totalCount = count($results);
+
+        // Summary
+        $output->writeln("<info>Results Summary:</info>");
+        $output->writeln("✅ Success: {$successCount}/{$totalCount}");
+        $output->writeln("❌ Failed: {$failureCount}/{$totalCount}");
+        $output->writeln('');
+
+        if (!empty($errors)) {
+            $output->writeln("<error>Failed Combinations:</error>");
+
+            $table = new Table($output);
+            $table->setHeaders(['Parser → Serializer', 'Error']);
+
+            foreach ($errors as $error) {
+                $errorMsg = $verboseErrors ? $error['error'] : $this->truncateError($error['error']);
+                $table->addRow([$error['combination'], $errorMsg]);
+            }
+
+            $table->render();
+            $output->writeln('');
+        }
+
+        $successRate = ($successCount / $totalCount) * 100;
+        $status = $successRate === 100.0 ? 'info' : ($successRate >= 80.0 ? 'comment' : 'error');
+        $output->writeln("<{$status}>Success Rate: " . number_format($successRate, 1) . "%</{$status}>");
+    }
+
+    protected function truncateError(string $error, int $maxLength = 80): string
+    {
+        if (strlen($error) <= $maxLength) {
+            return $error;
+        }
+
+        return substr($error, 0, $maxLength - 3) . '...';
+    }
+
+    protected function storagePath(string $file): string
+    {
+        if (str_starts_with($file, 'input')) {
+            return parent::storagePath($file);
+        }
+
+        // Get the current parser and serializer from the test context
+        $parser = $this->currentParser ?? 'unknown';
+        $serializer = $this->currentSerializer ?? 'unknown';
+        
+        $pathInfo = pathinfo($file);
+        $filename = $parser . '_' . $serializer;
+        $extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
+
+        return __DIR__ . '/../storage/' . $filename . $extension;
+    }
+}

--- a/examples/DownloadCommand.php
+++ b/examples/DownloadCommand.php
@@ -28,7 +28,7 @@ class DownloadCommand extends Command
         $logger->info('Navigate in your browser to http://localhost:8080');
         $logger->info('Type CTRL+C to exit');
 
-        $process->run(function ($type, $buffer) use ($logger) {
+        $process->run(function ($type, $buffer) use ($logger): void {
             $logger->info($buffer);
         });
 

--- a/examples/ExamplesCommand.php
+++ b/examples/ExamplesCommand.php
@@ -160,30 +160,30 @@ class ExamplesCommand extends Command
                 return $builder->serializeToCollection();
             case 'csv':
                 return $builder->serializeToCSVFile($outputPath . '.csv',
-                    function (SerializerConfigurator $configurator) {
+                    function (SerializerConfigurator $configurator): void {
                         $configurator->withHeader(['name', 'email']);
                     });
             case 'echo':
-                return $builder->serializeToEcho(function (EchoSerializerConfigurator $configurator) {
+                return $builder->serializeToEcho(function (EchoSerializerConfigurator $configurator): void {
                     $configurator->withPrefix('PERSIST');
                 });
             case 'excel':
                 return $builder->serializeToExcelFile($outputPath . '.xlsx',
-                    function (ExcelFileSerializerConfigurator $configurator) {
+                    function (ExcelFileSerializerConfigurator $configurator): void {
                         $configurator->withHeader(['name', 'email']);
 
-                        $configurator->withTrailler(function (SerializerAddonCallback $proxy) {
+                        $configurator->withTrailler(function (SerializerAddonCallback $proxy): void {
                             $proxy->append([$proxy->recordCount() . ' records']);
                             $proxy->append([($proxy->lineCount() + 1) . ' lines']);
                         });
 
-                        $configurator->withWorkbookConfigurator(function (WorkbookConfigurator $workbook) {
+                        $configurator->withWorkbookConfigurator(function (WorkbookConfigurator $workbook): void {
                             $workbook->setTitle('Workbook title');
                             $workbook->setCreator('Creator');
                             $workbook->setCompany('Company');
                         });
 
-                        $configurator->withWorksheetConfigurator(function (WorksheetConfigurator $worksheet) {
+                        $configurator->withWorksheetConfigurator(function (WorksheetConfigurator $worksheet): void {
                             $worksheet->setTitle('results', false);
 
                             $worksheet->withColumnFormat([
@@ -193,7 +193,7 @@ class ExamplesCommand extends Command
 
                             // header
                             $worksheet->freezeFirstRow();
-                            $worksheet->configureCells('A1:B1', function ($cells) {
+                            $worksheet->configureCells('A1:B1', function ($cells): void {
                                 $cells->setFontWeight('bold');
                                 $cells->setBorder('node', 'none', 'solid', 'none');
                             });
@@ -201,18 +201,18 @@ class ExamplesCommand extends Command
                         });
                     });
             case 'html':
-                return $builder->serializeToHTMLTable(function (HTMLTableSerializerConfigurator $configurator) {
+                return $builder->serializeToHTMLTable(function (HTMLTableSerializerConfigurator $configurator): void {
                     $configurator->withHeader(['name', 'email']);
                     $configurator->withTableClassAttribute('table table-condensed');
                     $configurator->withTableIdAttribute('my-table');
                 });
             case 'json':
                 return $builder->serializeToJSONFile($outputPath . '.json',
-                    function (JSONFileSerializerConfigurator $configurator) {
+                    function (JSONFileSerializerConfigurator $configurator): void {
                         $configurator->withEncodeOptions(JSONFileSerializer::JSON_ENCODE_OPTIONS | \JSON_PRETTY_PRINT);
                     });
             case 'log':
-                return $builder->serializeToLog(function (LogSerializerConfigurator $configurator) {
+                return $builder->serializeToLog(function (LogSerializerConfigurator $configurator): void {
                     $configurator->withPrefix('PERSIST');
                 });
             case 'pdo':

--- a/examples/RecordObjects/ExampleRecord.php
+++ b/examples/RecordObjects/ExampleRecord.php
@@ -2,7 +2,6 @@
 
 namespace RodrigoPedra\RecordProcessor\Examples\RecordObjects;
 
-use RodrigoPedra\RecordProcessor\Contracts\TextRecord;
 use RodrigoPedra\RecordProcessor\Records\SimpleRecord;
 
 class ExampleRecord extends SimpleRecord

--- a/examples/RecordObjects/ExampleRecord.php
+++ b/examples/RecordObjects/ExampleRecord.php
@@ -5,7 +5,7 @@ namespace RodrigoPedra\RecordProcessor\Examples\RecordObjects;
 use RodrigoPedra\RecordProcessor\Contracts\TextRecord;
 use RodrigoPedra\RecordProcessor\Records\SimpleRecord;
 
-class ExampleRecord extends SimpleRecord implements TextRecord
+class ExampleRecord extends SimpleRecord
 {
     public function isValid(): bool
     {

--- a/examples/download/download.php
+++ b/examples/download/download.php
@@ -10,7 +10,7 @@ $storagePath = __DIR__ . '/../../storage/';
 
 $processor = (new ProcessorBuilder())
     ->readFromCSVFile($storagePath . 'input.csv')
-    ->serializeToExcelFile($storagePath . 'output.xlsx', function (SerializerConfigurator $configurator) {
+    ->serializeToExcelFile($storagePath . 'output.xlsx', function (SerializerConfigurator $configurator): void {
         $configurator->withHeader(['name', 'email']);
     })
     ->downloadFileOutput('report.xlsx', DownloadFileOutput::DELETE_FILE_AFTER_DOWNLOAD)

--- a/examples/scripts/complex.php
+++ b/examples/scripts/complex.php
@@ -13,12 +13,12 @@ $storagePath = __DIR__ . '/../../storage/';
 $processor = (new ProcessorBuilder())
     ->readFromExcelFile($storagePath . 'input.xlsx')
     ->serializeToExcelFile($storagePath . 'output.xlsx')
-    ->serializeToHTMLTable(function (HTMLTableSerializerConfigurator $configurator) use ($storagePath) {
+    ->serializeToHTMLTable(function (HTMLTableSerializerConfigurator $configurator) use ($storagePath): void {
         $configurator->withRecordSerializer(new ExampleRecordSerializer());
 
         $configurator->withHeader(['name', 'email']);
 
-        $configurator->withTrailler(function (SerializerAddonCallback $serializer) {
+        $configurator->withTrailler(function (SerializerAddonCallback $serializer): void {
             $recordCount = $serializer->recordCount();
             $serializer->append($recordCount . ' records');
         });

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,51 @@ Process record-based sources using a pipeline approach
     exit;
 ```
 
-## TODO
+## Requirements
 
-Add documentation
+- PHP 8.2+
+- PDO extension (optional, for database operations)
+
+## Features
+
+- **Pipeline Architecture**: Uses Laravel's Pipeline component for record processing
+- **Multiple Data Sources**: CSV, Excel, PDO, Arrays, Collections, Iterators, Text files
+- **Multiple Output Formats**: CSV, Excel, HTML, JSON, PDO, Echo, Log, Text files
+- **Validation**: Built-in record validation and filtering
+- **Aggregation**: Group records by key with customizable aggregation
+- **Modern PHP**: Uses PHP 8.2+ features including readonly classes, enums, and type safety
+
+## Development Commands
+
+### Running Examples
+```bash
+# Run the console application with examples
+php console examples <parser> <serializer>
+
+# Available parsers: array|collection|csv|excel|iterator|pdo|text
+# Available serializers: array|collection|csv|echo|excel|html|json|log|pdo|pdo-buffered|text
+
+# Example usage:
+php console examples csv html
+php console examples excel json --log --aggregate
+```
+
+### Validation Commands
+```bash
+# Test all possible combinations of parsers and serializers
+php console all-examples
+
+# Test without PDO (if database is not available)
+php console all-examples --skip-pdo
+
+# Stop on first error (useful for CI/CD)
+php console all-examples --stop-on-error
+
+# Show detailed error messages
+php console all-examples --verbose-errors
+```
+
+### Download Command
+```bash
+php console download
+```

--- a/src/Concerns/HasCSVControls.php
+++ b/src/Concerns/HasCSVControls.php
@@ -2,6 +2,7 @@
 
 namespace RodrigoPedra\RecordProcessor\Concerns;
 
+use League\Csv\Bom;
 use RodrigoPedra\RecordProcessor\Support\NewLines;
 
 trait HasCSVControls
@@ -10,7 +11,7 @@ trait HasCSVControls
     protected string $enclosure = '"';
     protected string $escape = '\\';
     protected string $newline = NewLines::UNIX_NEWLINE;
-    protected string $outputBOM = '';
+    protected Bom $outputBOM;
 
     public function delimiter(): string
     {
@@ -32,7 +33,7 @@ trait HasCSVControls
         return $this->newline;
     }
 
-    public function outputBOM(): string
+    public function outputBOM(): Bom
     {
         return $this->outputBOM;
     }
@@ -77,7 +78,7 @@ trait HasCSVControls
         return $this;
     }
 
-    public function withOutputBOM(string $outputBOM): static
+    public function withOutputBOM(Bom $outputBOM): static
     {
         $this->outputBOM = $outputBOM;
 

--- a/src/Configurators/Serializers/ExcelFileSerializerConfigurator.php
+++ b/src/Configurators/Serializers/ExcelFileSerializerConfigurator.php
@@ -7,10 +7,10 @@ use RodrigoPedra\RecordProcessor\Serializers\ExcelFileSerializer;
 class ExcelFileSerializerConfigurator extends SerializerConfigurator
 {
     /** @var  callable|null */
-    protected $workbookConfigurator = null;
+    protected $workbookConfigurator;
 
     /** @var  callable|null */
-    protected $worksheetConfigurator = null;
+    protected $worksheetConfigurator;
 
     public function __construct(ExcelFileSerializer $serializer, bool $hasHeader = false, bool $hasTrailler = false)
     {

--- a/src/Contracts/Serializer.php
+++ b/src/Contracts/Serializer.php
@@ -6,7 +6,7 @@ use RodrigoPedra\RecordProcessor\Configurators\Serializers\SerializerConfigurato
 
 interface Serializer extends Resource
 {
-    public function append($content);
+    public function append($content): void;
 
     public function lineCount(): int;
 

--- a/src/Reader/CSVFileReader.php
+++ b/src/Reader/CSVFileReader.php
@@ -9,7 +9,7 @@ use RodrigoPedra\RecordProcessor\Contracts\Reader;
 use RodrigoPedra\RecordProcessor\Contracts\RecordParser;
 use RodrigoPedra\RecordProcessor\RecordParsers\ArrayRecordParser;
 
-class CSVFileReader extends FileReader implements Reader
+class CSVFileReader extends FileReader
 {
     use HasCSVControls;
 

--- a/src/Reader/CSVFileReader.php
+++ b/src/Reader/CSVFileReader.php
@@ -5,7 +5,6 @@ namespace RodrigoPedra\RecordProcessor\Reader;
 use League\Csv\Reader as CsvReader;
 use RodrigoPedra\RecordProcessor\Concerns\HasCSVControls;
 use RodrigoPedra\RecordProcessor\Configurators\Readers\CSVFileReaderConfigurator;
-use RodrigoPedra\RecordProcessor\Contracts\Reader;
 use RodrigoPedra\RecordProcessor\Contracts\RecordParser;
 use RodrigoPedra\RecordProcessor\RecordParsers\ArrayRecordParser;
 

--- a/src/Reader/ExcelFileReader.php
+++ b/src/Reader/ExcelFileReader.php
@@ -8,7 +8,7 @@ use RodrigoPedra\RecordProcessor\Configurators\Readers\ExcelFileReaderConfigurat
 use RodrigoPedra\RecordProcessor\Contracts\Reader;
 use RodrigoPedra\RecordProcessor\RecordParsers\ArrayRecordParser;
 
-class ExcelFileReader extends FileReader implements Reader
+class ExcelFileReader extends FileReader
 {
     protected int $skipRows = 0;
     protected int $selectedSheetIndex = 0;

--- a/src/Reader/ExcelFileReader.php
+++ b/src/Reader/ExcelFileReader.php
@@ -5,7 +5,6 @@ namespace RodrigoPedra\RecordProcessor\Reader;
 use Illuminate\Support\Collection;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use RodrigoPedra\RecordProcessor\Configurators\Readers\ExcelFileReaderConfigurator;
-use RodrigoPedra\RecordProcessor\Contracts\Reader;
 use RodrigoPedra\RecordProcessor\RecordParsers\ArrayRecordParser;
 
 class ExcelFileReader extends FileReader

--- a/src/Records/RecordKeyAggregate.php
+++ b/src/Records/RecordKeyAggregate.php
@@ -73,6 +73,21 @@ class RecordKeyAggregate implements RecordAggregate
         return $this->master->{$name};
     }
 
+    public function __set(string $name, mixed $value): void
+    {
+        throw new \BadMethodCallException('Cannot set properties on RecordKeyAggregate. Use the master record instead.');
+    }
+
+    public function __isset(string $name): bool
+    {
+        return isset($this->master->{$name});
+    }
+
+    public function __unset(string $name): void
+    {
+        throw new \BadMethodCallException('Cannot unset properties on RecordKeyAggregate. Use the master record instead.');
+    }
+
     public function __call(string $name, array $arguments)
     {
         return $this->forwardCallTo($this->master, $name, $arguments);

--- a/src/Serializers/ArraySerializer.php
+++ b/src/Serializers/ArraySerializer.php
@@ -25,7 +25,7 @@ class ArraySerializer implements Serializer
     {
     }
 
-    public function append($content)
+    public function append($content): void
     {
         $this->items[] = $content;
     }

--- a/src/Serializers/CSVFileSerializer.php
+++ b/src/Serializers/CSVFileSerializer.php
@@ -49,7 +49,7 @@ class CSVFileSerializer extends FileSerializer implements ByteSequence
     /**
      * @throws \League\Csv\CannotInsertRecord
      */
-    public function append($content)
+    public function append($content): void
     {
         $this->writer->insertOne(Arr::wrap($content));
 

--- a/src/Serializers/CSVFileSerializer.php
+++ b/src/Serializers/CSVFileSerializer.php
@@ -3,13 +3,13 @@
 namespace RodrigoPedra\RecordProcessor\Serializers;
 
 use Illuminate\Support\Arr;
-use League\Csv\ByteSequence;
+use League\Csv\Bom;
 use League\Csv\Writer;
 use RodrigoPedra\RecordProcessor\Concerns\HasCSVControls;
 use RodrigoPedra\RecordProcessor\Configurators\Serializers\CSVFileSerializerConfigurator;
 use RodrigoPedra\RecordProcessor\Support\NewLines;
 
-class CSVFileSerializer extends FileSerializer implements ByteSequence
+class CSVFileSerializer extends FileSerializer
 {
     use HasCSVControls;
 
@@ -19,9 +19,10 @@ class CSVFileSerializer extends FileSerializer implements ByteSequence
     {
         parent::__construct($file);
 
+        $this->outputBOM = Bom::Utf8; // Initialize before using trait methods
         $this->withDelimiter(';');
         $this->withNewline(NewLines::WINDOWS_NEWLINE);
-        $this->withOutputBOM(static::BOM_UTF8);
+        $this->withOutputBOM(Bom::Utf8);
 
         $this->configurator = new CSVFileSerializerConfigurator($this, true, true);
     }

--- a/src/Serializers/CollectionSerializer.php
+++ b/src/Serializers/CollectionSerializer.php
@@ -26,7 +26,7 @@ class CollectionSerializer implements Serializer
     {
     }
 
-    public function append($content)
+    public function append($content): void
     {
         $this->collection->push($content);
     }

--- a/src/Serializers/EchoSerializer.php
+++ b/src/Serializers/EchoSerializer.php
@@ -23,7 +23,7 @@ class EchoSerializer extends FileSerializer
         $this->lineCount = 0;
     }
 
-    public function append($content)
+    public function append($content): void
     {
         $prefix = $this->prefix();
 

--- a/src/Serializers/ExcelFileSerializer.php
+++ b/src/Serializers/ExcelFileSerializer.php
@@ -58,7 +58,7 @@ class ExcelFileSerializer extends FileSerializer
     /**
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    public function append($content)
+    public function append($content): void
     {
         if ($this->lineCount() === static::ROW_LIMIT) {
             throw new \RuntimeException(

--- a/src/Serializers/HTMLTableSerializer.php
+++ b/src/Serializers/HTMLTableSerializer.php
@@ -78,7 +78,7 @@ class HTMLTableSerializer implements Serializer
         $this->records = [];
     }
 
-    public function append($content)
+    public function append($content): void
     {
         $this->records[] = Arr::wrap($content);
 

--- a/src/Serializers/JSONFileSerializer.php
+++ b/src/Serializers/JSONFileSerializer.php
@@ -35,7 +35,7 @@ class JSONFileSerializer extends FileSerializer
         $this->file->fwrite(']');
     }
 
-    public function append($content)
+    public function append($content): void
     {
         if ($content instanceof \JsonSerializable) {
             $content = \json_encode($content->jsonSerialize(), $this->jsonEncodeOptions);

--- a/src/Serializers/LogSerializer.php
+++ b/src/Serializers/LogSerializer.php
@@ -65,7 +65,7 @@ class LogSerializer implements Serializer, LoggerAwareInterface
         $this->incrementLineCount();
     }
 
-    public function output()
+    public function output(): null
     {
         return null;
     }

--- a/src/Serializers/LogSerializer.php
+++ b/src/Serializers/LogSerializer.php
@@ -58,7 +58,7 @@ class LogSerializer implements Serializer, LoggerAwareInterface
     {
     }
 
-    public function append($content)
+    public function append($content): void
     {
         $this->logger->log($this->level, $this->prefix(), Arr::wrap($content));
 

--- a/src/Serializers/PDOBufferedSeriealizer.php
+++ b/src/Serializers/PDOBufferedSeriealizer.php
@@ -18,7 +18,7 @@ class PDOBufferedSeriealizer extends PDOSerializer
         parent::close();
     }
 
-    public function append($content)
+    public function append($content): void
     {
         if (! \is_array($content)) {
             throw new \InvalidArgumentException('content for PDOBufferedSerializer should be an array');

--- a/src/Serializers/PDOSerializer.php
+++ b/src/Serializers/PDOSerializer.php
@@ -92,7 +92,7 @@ class PDOSerializer implements Serializer
         }
     }
 
-    public function output()
+    public function output(): null
     {
         return null;
     }

--- a/src/Serializers/PDOSerializer.php
+++ b/src/Serializers/PDOSerializer.php
@@ -67,7 +67,7 @@ class PDOSerializer implements Serializer
     /**
      * @throws \Throwable
      */
-    public function append($content)
+    public function append($content): void
     {
         if (! \is_array($content)) {
             throw new \InvalidArgumentException('Content for PDOSerializer should be an array');

--- a/src/Serializers/TextFileSerializer.php
+++ b/src/Serializers/TextFileSerializer.php
@@ -29,7 +29,7 @@ class TextFileSerializer extends FileSerializer
         return $this;
     }
 
-    public function append($content)
+    public function append($content): void
     {
         if (! \is_string($content)) {
             throw new \InvalidArgumentException('Content for TextFileSerializer should be a string');

--- a/src/Stages/DownloadFileOutput.php
+++ b/src/Stages/DownloadFileOutput.php
@@ -2,6 +2,7 @@
 
 namespace RodrigoPedra\RecordProcessor\Stages;
 
+use League\Csv\Exception;
 use League\Csv\Reader;
 use RodrigoPedra\RecordProcessor\Contracts\ProcessorStageFlusher;
 use RodrigoPedra\RecordProcessor\Serializers\CSVFileSerializer;
@@ -54,7 +55,7 @@ class DownloadFileOutput implements ProcessorStageFlusher
         return $inputFile;
     }
 
-    protected function downloadFile()
+    protected function downloadFile(): void
     {
         if ($this->inputFileInfo->isCSV()) {
             $this->outputFileWithLeagueCSV($this->inputFile);
@@ -84,14 +85,17 @@ class DownloadFileOutput implements ProcessorStageFlusher
         \header('Content-Disposition: attachment; filename="' . $filename . '"');
     }
 
+    /**
+     * @throws Exception
+     */
     protected function outputFileWithLeagueCSV(\SplFileObject $file)
     {
         // league\csv handles CSV BOM properly
         $reader = Reader::createFromFileObject($file);
-        $reader->output($this->outputFileInfo->getBasename());
+        $reader->download($this->outputFileInfo->getBasename());
     }
 
-    protected function buildOutputFileInfo(?string $className)
+    protected function buildOutputFileInfo(?string $className): void
     {
         if (\is_string($this->outputFile)) {
             $this->outputFileInfo = new FileInfo($this->outputFile);
@@ -115,7 +119,7 @@ class DownloadFileOutput implements ProcessorStageFlusher
         $this->outputFileInfo = $this->inputFileInfo;
     }
 
-    protected function unlinkInputFile()
+    protected function unlinkInputFile(): void
     {
         if (! $this->deleteAfterDownload) {
             return;
@@ -135,7 +139,7 @@ class DownloadFileOutput implements ProcessorStageFlusher
 
     protected function buildTempOutputFileInfo(?string $className): FileInfo
     {
-        $fileName = \implode('_', ['temp', \uniqid(\date('YmdHis'))]);
+        $fileName = \implode('_', ['temp', \uniqid(\date('YmdHis'), true)]);
 
         $fileName = match ($className) {
             CSVFileSerializer::class => $fileName . '.csv',

--- a/src/Stages/Writer.php
+++ b/src/Stages/Writer.php
@@ -50,7 +50,7 @@ final class Writer implements ProcessorStageHandler, ProcessorStageFlusher
         }
 
         if ($payload->hasRecord()) {
-            $this->handle($payload->record(), fn () => null);
+            $this->handle($payload->record(), fn (): null => null);
         }
 
         $this->close();

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,2 +1,5 @@
-*.sqlite
-*output.*
+*
+!.gitignore
+!input.csv
+!input.txt
+!input.xlsx


### PR DESCRIPTION
Updates dependencies to support PHP 8.2 and Symfony 7.3.

Adds an `all-examples` command to test all combinations of parsers and serializers for validation purposes.
- Introduces a new command to test all parser/serializer combinations
- Updates dependencies including PHP version and Symfony components
- Uses league/csv for improved CSV handling